### PR TITLE
Feature: Amnesty script font fix from UIDS

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "build": "vite build --assetsDir=assets --minify=esbuild"
   },
   "dependencies": {
-    "@uiowa/uids": "uiowa/uids#41b3d33",
+    "@uiowa/uids": "uiowa/uids#3cb7c54",
     "vue": "^3.0.0-rc.1"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -282,10 +282,10 @@
   dependencies:
     "@types/express-serve-static-core" "*"
     "@types/mime" "*"
-    
-"@uiowa/uids@uiowa/uids#41b3d33":
+
+"@uiowa/uids@uiowa/uids#3cb7c54":
   version "3.0.2"
-  resolved "https://codeload.github.com/uiowa/uids/tar.gz/41b3d3365517ce817ddbe6c946ced8db9a5c6e6a"
+  resolved "https://codeload.github.com/uiowa/uids/tar.gz/3cb7c54fcfd3ee4906486f2a689480f1c0d472e6"
   dependencies:
     autoprefixer "^9.8.0"
     cssnano "^4.1.10"


### PR DESCRIPTION
This is meant to fix this font issue:

<img width="704" alt="Screen Shot 2020-08-27 at 12 38 02 PM" src="https://user-images.githubusercontent.com/1036433/91476137-2f866f80-e862-11ea-8828-c525219a627d.png">
