### PR TITLE
reduce cta paddings/margins on smaller devices

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -687,4 +687,24 @@ export default {
     margin-left: 1.875rem;
   }
 
+
+  // Override and condense for smaller devices.
+  .cta-row__wrapper {
+    transition: padding 0.5s ease;
+    padding: 0.5rem 0;
+    .cta-row__container .menu a {
+      transition: margin 0.5s ease;
+      margin: 0px .5rem;
+      padding-bottom: 0.5rem;
+    }
+  }
+  @media (min-height: 800px) {
+    .cta-row__wrapper {
+      padding: 1.875rem 0;
+      .cta-row__container .menu a {
+        margin: 0px 1.05rem;
+      }
+    }
+  }
+
 </style>

--- a/src/App.vue
+++ b/src/App.vue
@@ -687,15 +687,17 @@ export default {
     margin-left: 1.875rem;
   }
 
-
   // Override and condense for smaller devices.
   .cta-row__wrapper {
     transition: padding 0.5s ease;
-    padding: 0.5rem 0;
+    padding: 0.3rem 0;
     .cta-row__container .menu a {
       transition: margin 0.5s ease;
       margin: 0px .5rem;
       padding-bottom: 0.5rem;
+    }
+    .bttn--outline {
+      border: none;
     }
   }
   @media (min-height: 800px) {
@@ -703,6 +705,9 @@ export default {
       padding: 1.875rem 0;
       .cta-row__container .menu a {
         margin: 0px 1.05rem;
+      }
+      .bttn--outline {
+        border: 1px solid rgb(21, 21, 21);
       }
     }
   }


### PR DESCRIPTION
Resolves #47

Overrides to reduce paddings/margins for the CTA on smaller devices. Cute transitions for device re-sizing effect.

1380 x 799px display (updated 10:30 11/5)
<img width="1044" alt="Screen Shot 2020-11-05 at 10 29 36 AM" src="https://user-images.githubusercontent.com/4663676/98268233-e5042c00-1f51-11eb-91d5-f6ac31aa4d58.png">
